### PR TITLE
Fix bug in @property trigger_type concerning the instantiation of TriggerType

### DIFF
--- a/src/lecroyutils/control.py
+++ b/src/lecroyutils/control.py
@@ -125,7 +125,7 @@ class LecroyScope:
 
     @property
     def trigger_type(self) -> TriggerType:
-        return TriggerType(self._read('app.Acquisition.Trigger.Type'))
+        return TriggerType(self._read('app.Acquisition.Trigger.Type').upper())
 
     @trigger_type.setter
     def trigger_type(self, new_type: TriggerType):


### PR DESCRIPTION
## Problem
I am using a LeCroy Waverunner 104Xi-A. When reading the trigger type, it returns a single word with capitalized first letter, e.g.: `Edge`. The code below expects a fully capitalized single word, which would be `EDGE` in the example case.

https://github.com/sibartel/lecroyutils/blob/18a7026ddc76a95c6d6c306300569afd6b5558c2/src/lecroyutils/control.py#L126-L128

## Solution
I have made the instantiation more general by adding the call to `str.upper()` to the request. This change does not break compatibility with other hardware, while including compatibility with slightly different implementations of the firmware. 

```python
 @property 
 def trigger_type(self) -> TriggerType: 
     return TriggerType(self._read('app.Acquisition.Trigger.Type'.upper())) 
```